### PR TITLE
removes CSS color to radio button label

### DIFF
--- a/public/css/public.css
+++ b/public/css/public.css
@@ -3,7 +3,6 @@
  */
 #gdrf-radio-label {
 	font-weight: 800;
-	color: #333;
 	display: block;
 	margin-bottom: .5em;
 }


### PR DESCRIPTION
Remove color CSS declaration from `#gdrf-radio-label` rule, to handle theme background color.
Props [@wolly](https://profiles.wordpress.org/wolly)