### PR TITLE
Enqueue styles and scripts only when necessary

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -11,21 +11,18 @@
  * @prefix     gdrf_
  */
 
-	add_action( 'wp_enqueue_scripts', 'enqueue_styles_gdrf_public' );
-	function enqueue_styles_gdrf_public() {
-		wp_enqueue_style( 'gdrf-public-styles', plugin_dir_url( __FILE__ ) . 'css/public.css', array(), '', 'all' );
-	}
+add_action( 'wp_enqueue_scripts', 'enqueue_styles_gdrf_public' );
+function enqueue_styles_gdrf_public() {
+	wp_register_style( 'gdrf-public-styles', plugin_dir_url( __FILE__ ) . 'css/public.css', array(), '', 'all' );
+}
 
- 	add_action( 'wp_enqueue_scripts', 'enqueue_scripts_gdrf_public' );
-	function enqueue_scripts_gdrf_public() {
-		wp_register_script( 'gdrf-public-scripts', plugin_dir_url( __FILE__ ) . 'js/gdrf-public.js', array( 'jquery' ), '', false );
-		$translations = array(
-			'gdrf_ajax_url' => esc_url( admin_url( 'admin-ajax.php' ) ),
-			'gdrf_success' => __( 'Your enquiry have been submitted. Check your email to validate your data request.', 'gdpr-data-request-form' ),
-			'gdrf_errors' => __( 'Some errors occurred:', 'gdpr-data-request-form' ),
-		);
-		wp_localize_script( 'gdrf-public-scripts', 'gdrf_localize', $translations );
-		wp_enqueue_script( 'gdrf-public-scripts' );
-	}
-
-	
+add_action( 'wp_enqueue_scripts', 'enqueue_scripts_gdrf_public' );
+function enqueue_scripts_gdrf_public() {
+	wp_register_script( 'gdrf-public-scripts', plugin_dir_url( __FILE__ ) . 'js/gdrf-public.js', array( 'jquery' ), '', false );
+	$translations = array(
+		'gdrf_ajax_url' => esc_url( admin_url( 'admin-ajax.php' ) ),
+		'gdrf_success'  => __( 'Your enquiry have been submitted. Check your email to validate your data request.', 'gdpr-data-request-form' ),
+		'gdrf_errors'   => __( 'Some errors occurred:', 'gdpr-data-request-form' ),
+	);
+	wp_localize_script( 'gdrf-public-scripts', 'gdrf_localize', $translations );
+}

--- a/public/shortcode.php
+++ b/public/shortcode.php
@@ -13,6 +13,12 @@
 
 function gdrf_shortcode_init() {
 	function gdrf_shortcode_data_request( $atts ) {
+
+		// Enqueue CSS/JS
+		wp_enqueue_script( 'gdrf-public-scripts' );
+		wp_enqueue_style( 'gdrf-public-styles' );
+
+		// Display the form
 		ob_start();
 		?>
 			<form action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" method="post" id="gdrf-form">

--- a/public/widget.php
+++ b/public/widget.php
@@ -27,7 +27,12 @@ class GDRF_Widget extends WP_Widget {
 	}
 
 	public function widget( $args, $instance ) {
-		
+
+		// Enqueue CSS/JS
+		wp_enqueue_script( 'gdrf-public-scripts' );
+		wp_enqueue_style( 'gdrf-public-styles' );
+
+		// Display the form
 		?>
 			<form action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" method="post" id="gdrf-form" class="widget widget_gdrf">
 				<input type="hidden" name="action" value="gdrf_data_request">


### PR DESCRIPTION
Let's enqueue scripts and styles only when a shortcode/widget is present in the current page.
Props [@juliobox](https://profiles.wordpress.org/juliobox/)