### PR TITLE
form instance widget title & text

### DIFF
--- a/public/widget.php
+++ b/public/widget.php
@@ -104,8 +104,8 @@ class GDRF_Widget extends WP_Widget {
  
     public function form( $instance ) {
  
-        $title = ! empty( $instance['title'] ) ? $instance['title'] : esc_html__( '', 'gdpr-data-request-form' );
-        $text = ! empty( $instance['text'] ) ? $instance['text'] : esc_html__( '', 'gdpr-data-request-form' );
+		$title = ( ! empty( $instance['title'] ) ) ? $instance['title'] : '';
+		$text  = ( ! empty( $instance['text'] ) ) ? $instance['text'] : '';
 
         ?>
 


### PR DESCRIPTION
uses the same ternary as in `update()` function as well and remove the "emptry" translation strings as they are not needed.