### PR TITLE
Simplify form data serialization when submitting form with AJAX.

### DIFF
--- a/public/js/gdrf-public.js
+++ b/public/js/gdrf-public.js
@@ -1,28 +1,13 @@
 ( function( $ ) {
 	'use strict';
-	
+
 	jQuery(document).ready(function() {
 
 		$( '#gdrf-form' ).on( 'submit', function( event ) {
-			
+
 			event.preventDefault();
-			
-			var data_type = '';		
-			if ( $( 'input[name=gdrf_data_type]' ).is( ':checkbox' ) ) {
-				data_type = $( 'input[name=gdrf_data_type]:checked', '#gdrf-form').val();
-			} else {
-				data_type = $( 'input[name=gdrf_data_type]', '#gdrf-form').val();
-			}
-			
-			var	button = $( '#gdrf-submit-button' ),
-				data = {
-					'action':               'gdrf_data_request',
-					'gdrf_data_type' :      data_type,
-					'gdrf_data_human_key':  $( '#gdrf_data_human_key' ).val(),
-					'gdrf_data_email':      $( '#gdrf_data_email' ).val(),
-					'gdrf_data_human':      $( '#gdrf_data_human' ).val(),
-					'gdrf_data_nonce':      $( '#gdrf_data_nonce' ).val(),
-				};
+
+			var data = $( this ).serialize();
 
 			$( '.gdrf-errors' ).remove();
 			$( '.gdrf-success' ).remove();


### PR DESCRIPTION
I had a problem on a client website where all requests were going to the export data list no matter what type of action the user selected. After debugging the issue for a while I found that the value for the action, sent to the server was always `export_personal_data` even when the `export_personal_data` radio was checked. The problem was on https://github.com/audrasjb/gdpr-data-request-form/blob/57d2e5352228190089e901c0018d357dcaf8a283/public/js/gdrf-public.js#L11 - it is checking for a checkbox, but the inputs are radios. To fix this and avoid such mistakes in the future I think it's best to just use 'jQuery().serialize()` method when sending form data in AJAX calls.