### PR TITLE
Updated Plugin Headers

### DIFF
--- a/gdpr-data-request-form.php
+++ b/gdpr-data-request-form.php
@@ -8,13 +8,13 @@
  * @wordpress-plugin
  * Plugin Name:       GDPR Data Request Form
  * Plugin URI:        https://jeanbaptisteaudras.com/gdpr-data-request-form
- * Description:       Use WordPress Core GDPR tools to build front-end Personal Data export/erasure forms (includes Widget, Gutenberg Block, shortcode & Hooks).
+ * Description:       Use WordPress Core GDPR tools to build front-end Personal Data export/erasure forms (includes Widget, Gutenberg Block, Shortcode & Hooks).
  * Version:           1.4.2
+ * Requires at least: 4.9.6
  * Author:            audrasjb
  * Author URI:        https://jeanbaptisteaudras.com
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
- * Text Domain:       gdpr-data-request-form
  */
 
 // If this file is called directly, abort.


### PR DESCRIPTION
Added 'Requires at least' to be 4.9.6 as the privacy tools are a requirement.
Removed the Text Domain as we're requiring > 4.6 we don't require that header.
Reference - https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains

Note: We can also add the 'Requires PHP' header to indicate minimum PHP but I feel we have no specific requirements beyond what WP has so no need for that header.